### PR TITLE
Fix bug: shorten token refresh interval in sendReminder as in sendSurvey

### DIFF
--- a/cron/surveys/invitation.ts
+++ b/cron/surveys/invitation.ts
@@ -66,7 +66,7 @@ export const sendSurvey = async () => {
       tokenCounter++
       counter++
       //console.log(tokenCounter)
-      //refresh token every 400 emails
+      //refresh token every 100 emails
       if (tokenCounter === 100) {
         console.log("Refreshing token")
         token = await getToken()

--- a/cron/surveys/reminder.ts
+++ b/cron/surveys/reminder.ts
@@ -90,8 +90,8 @@ export const sendReminder = async (interval: number, surveyType: string, reminde
                     })
                 tokenCounter++
                 counter++
-                //refresh token every 400 emails
-                if (tokenCounter === 400) {
+                //refresh token every 100 emails
+                if (tokenCounter === 100) {
                     console.log("Refreshing token")
                     token = await getToken()
                     tokenCounter = 0


### PR DESCRIPTION
This fixes a bug where some reminders could fail due to token expiry when there were many reminders. This fix was previously implemented for invites but appears to have been overlooked for reminders.