### PR TITLE
fix reminder email date bug

### DIFF
--- a/cron/surveys/reminder.ts
+++ b/cron/surveys/reminder.ts
@@ -60,7 +60,7 @@ export const sendReminder = async (
         } else {
           email = recipient.email;
         }
-        //console.log(emailContent)
+        const daysLeft = 30 - interval; // magic number 30 is the current survey lifespan (see app.ts)
         await sendEmail(
           token as string,
           generateHTMLEmail(
@@ -82,8 +82,8 @@ export const sendReminder = async (
                 contactId: recipient.contactId,
                 endDate:
                   recipient.language.toUpperCase() === "FR"
-                    ? moment().locale("fr").add(16, "days").format("LL")
-                    : moment().add(16, "days").format("LL"),
+                    ? moment().locale("fr").add(daysLeft, "days").format("LL")
+                    : moment().add(daysLeft, "days").format("LL"),
                 lastName: recipient.lastName,
               },
             },


### PR DESCRIPTION
The date calculation in the final reminder email for the surveys is currently bugged. The 1st reminder email has the correct date, i.e. today's date + 16 days, however the 2nd (final) reminder is using the same calculation when it should just be today's date.

